### PR TITLE
Add transit windows API endpoint

### DIFF
--- a/controllers/transitController.js
+++ b/controllers/transitController.js
@@ -1,0 +1,28 @@
+import { generateTransitSeries, scanTransitSeries, mergeTransitWindows } from '../services/ephemerisDataService.js';
+
+export async function handleGetTransitWindows(req, res) {
+  try {
+    const { natalPlanets, from, to } = req.body;
+    if (!Array.isArray(natalPlanets) || !from || !to) {
+      return res.status(400).json({ error: 'natalPlanets, from and to are required' });
+    }
+
+    const fromDate = new Date(from);
+    const toDate = new Date(to);
+
+    const series = generateTransitSeries(fromDate, toDate);
+
+    const natal = natalPlanets.map(p => ({
+      name: p.name,
+      lon: p.lon ?? p.full_degree ?? p.fullDegree
+    }));
+
+    const rawEvents = Array.from(scanTransitSeries(series, natal));
+    const windows = mergeTransitWindows(rawEvents);
+
+    res.json({ rawEvents, windows });
+  } catch (error) {
+    console.error('Error generating transit windows:', error);
+    res.status(500).json({ error: 'Server error' });
+  }
+}

--- a/routes/indexRoutes.js
+++ b/routes/indexRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 const router = express.Router();
 
-import { 
+import {
     handleUserCreation, 
     handleCreateRelationship
 } from '../controllers/astroDataController.js';
@@ -23,6 +23,9 @@ import {
     handleProcessUserQueryForRelationshipAnalysis,
     handleFetchUserChatRelationshipAnalysis
 } from '../controllers/gptController.js';
+import {
+    handleGetTransitWindows
+} from '../controllers/transitController.js';
 import { 
     handleSaveCompositeChartProfile,
     handleSaveSynastryChartInterpretation,
@@ -83,5 +86,7 @@ router.post('/fetchUserChatBirthChartAnalysis', handleFetchUserChatBirthChartAna
 router.post('/userChatRelationshipAnalysis', handleProcessUserQueryForRelationshipAnalysis);
 
 router.post('/fetchUserChatRelationshipAnalysis',  handleFetchUserChatRelationshipAnalysis);
+
+router.post('/getTransitWindows', handleGetTransitWindows);
 
 export default router;

--- a/serverless.yml
+++ b/serverless.yml
@@ -433,6 +433,14 @@ functions:
           timeout: 300
           method: options
           cors: true
+      - http:
+          path: /getTransitWindows
+          method: post
+          cors: true
+      - http:
+          path: /getTransitWindows
+          method: options
+          cors: true
 custom:
   serverless-offline:
     httpPort: 3001


### PR DESCRIPTION
## Summary
- implement `handleGetTransitWindows` controller
- wire up new route `/getTransitWindows`
- expose endpoint in serverless configuration

## Testing
- `node scripts/testTransitFunctions.js` *(fails: Cannot find package 'sweph')*