### PR TITLE
Add createUserUnknownTime endpoints

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -334,6 +334,14 @@ functions:
           method: options
           cors: true
       - http:
+          path: /createUserUnknownTime
+          method: post
+          cors: true
+      - http:
+          path: /createUserUnknownTime
+          method: options
+          cors: true
+      - http:
           path: /createRelationship
           method: post
           cors: true


### PR DESCRIPTION
## Summary
- extend serverless config with POST/OPTIONS for `/createUserUnknownTime`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683b59e810008327bb1babf6c3d64f3c