### PR TITLE
Handle unknown birth times

### DIFF
--- a/controllers/astroDataController.ts
+++ b/controllers/astroDataController.ts
@@ -3,6 +3,7 @@
 import { saveUser, saveCompositeChart, getPreGeneratedTransitSeries } from '../services/dbService.js';
 import {
   getRawChartDataEphemeris,
+  getRawChartDataEphemerisNoTime,
   findSynastryAspects,
   generateCompositeChart,
   scanTransitSeries,
@@ -107,6 +108,49 @@ export const handleCreateRelationship = async (req, res) => {
   res.setHeader('Access-Control-Allow-Credentials', true);
   res.status(200).json({ relationshipProfile });
 }
+
+export async function handleUserCreationUnknownTime(req, res) {
+  try {
+    const { firstName, lastName, gender, placeOfBirth, dateOfBirth, email, lat, lon, tzone } = req.body;
+
+    const date = new Date(dateOfBirth);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+
+    const chartData = await getRawChartDataEphemerisNoTime({
+      year,
+      month,
+      day,
+      lat: parseFloat(lat),
+      lon: parseFloat(lon),
+      tzone: parseFloat(tzone)
+    });
+
+    const user = {
+      email,
+      firstName,
+      lastName,
+      gender,
+      dateOfBirth,
+      placeOfBirth,
+      totalOffsetHours: tzone,
+      birthTimeUnknown: true,
+      birthChart: chartData
+    };
+
+    const saveUserResponse = await saveUser(user);
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
+    res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
+    res.setHeader('Access-Control-Allow-Credentials', true);
+
+    res.json({ user, saveUserResponse });
+  } catch (error) {
+    console.error('Error in handleUserCreationUnknownTime:', error);
+    res.status(500).send('Server error');
+  }
+};
 
 
 

--- a/routes/indexRoutes.ts
+++ b/routes/indexRoutes.ts
@@ -3,7 +3,8 @@ import express from 'express';
 const router = express.Router();
 
 import {
-    handleUserCreation, 
+    handleUserCreation,
+    handleUserCreationUnknownTime,
     handleCreateRelationship,
     handleGetTransitWindows
 } from '../controllers/astroDataController.js';
@@ -51,6 +52,7 @@ router.post('/saveSynastryChartInterpretation', handleSaveSynastryChartInterpret
 
 // using sweph/ephemeris
 router.post('/createUser', handleUserCreation);
+router.post('/createUserUnknownTime', handleUserCreationUnknownTime);
 router.post('/createRelationship', handleCreateRelationship);
 router.post('/getRelationshipScore', handleGetRelationshipScore);
 router.post('/fetchRelationshipAnalysis', handleFetchRelationshipAnalysis);

--- a/services/ephemerisDataService.ts
+++ b/services/ephemerisDataService.ts
@@ -168,6 +168,25 @@ export async function getRawChartDataEphemeris(data) {
   return rawResponse;
 }
 
+export async function getRawChartDataEphemerisNoTime(data) {
+  const base = await getRawChartDataEphemeris({
+    ...data,
+    hour: 12,
+    min: 0
+  });
+
+  base.planets = base.planets.filter(p => {
+    const name = p.name.toLowerCase();
+    return name !== 'ascendant' && name !== 'midheaven' && name !== 'mc';
+  });
+  base.houses = [];
+  base.aspects = findAspectsForBirthChart(base.planets);
+  base.ascendant = 0;
+  base.midheaven = 0;
+  base.birthTimeUnknown = true;
+  return base;
+}
+
 
 function generatePlanetObjectSweph(name, full_degree, house_number) {
   return {

--- a/utilities/birthChartScoring.ts
+++ b/utilities/birthChartScoring.ts
@@ -152,27 +152,30 @@ export const generateNatalPromptsShortOverview = (birthData) => {
 
 
 export const getRulerPlanet = (birthData) => {
-    let ascendant = birthData.planets.find(p => p.name === "Ascendant" || p.name === "ascendant")
-    let chartRulerPlanet = rulers[ascendant.sign]
-    return chartRulerPlanet
+    const ascendant = birthData.planets?.find(p => p.name === "Ascendant" || p.name === "ascendant")
+    if (!ascendant) return undefined;
+    return rulers[ascendant.sign]
   }
 
   export const getDescendantRuler = (birthData) => {
-    let fourthHouse = birthData.houses.find(h => h.house === 4)
-    let fourthHouseSign = fourthHouse.sign
-    let fourthHouseRuler = rulers[fourthHouseSign]
-    return fourthHouseRuler
+    const fourthHouse = birthData.houses?.find(h => h.house === 4)
+    if (!fourthHouse) return undefined;
+    return rulers[fourthHouse.sign]
   }
 
   const getHouseRuler = (birthData, house) => {
-    let houseSign = birthData.houses.find(h => h.house === house).sign
-    let houseRuler = rulers[houseSign]
-    return houseRuler
+    const houseObj = birthData.houses?.find(h => h.house === house)
+    if (!houseObj) return undefined;
+    return rulers[houseObj.sign]
   }
 
 
 export const generateTopicMapping = (birthData) => {
     console.log("generateTopicMapping")
+    if (!birthData.houses || birthData.houses.length === 0) {
+        console.warn("generateTopicMapping: birth data missing houses");
+        return {};
+    }
     const chartRulerPlanet = getHouseRuler(birthData, 1);
     const descendantRuler = getHouseRuler(birthData, 7);
     const fourthHouseRuler = getHouseRuler(birthData, 4);
@@ -197,6 +200,9 @@ export const generateTopicMapping = (birthData) => {
 
   export const generateRelevantNatalPositions = (promptKey, birthData, rulerMapping) => {
     console.log("generateRelevantNatalPositions");
+    if (!birthData.houses || birthData.houses.length === 0) {
+        return "";
+    }
     const prompt = relevantPromptAspectsV2[promptKey];
     let responses = [];
     let usedCodes = new Set();  // Track used codes

--- a/utilities/relationshipScoring.ts
+++ b/utilities/relationshipScoring.ts
@@ -571,7 +571,7 @@ function getSign(degree) {
 
   function getHouse(birthChartPlanets, planetName) {
     const house = birthChartPlanets.find(planet => planet.name.toLowerCase() === planetName.toLowerCase())?.house;
-    return house;
+    return house ?? 0;
   }
 
 // function addMaxPossibleScore(aspectType) {


### PR DESCRIPTION
## Summary
- add an endpoint and controller for creating a user without birth time
- expose `getRawChartDataEphemerisNoTime` in ephemeris service
- gracefully handle missing houses and ascendant in scoring utilities
- default house lookup to `0` when unavailable

## Testing
- `npm run build`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683b53ca74d88327b784b22d8278a891